### PR TITLE
Improve company name resolution and add tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit
 yahooquery
 pandas
+pytest

--- a/tests/test_stock_dashboard.py
+++ b/tests/test_stock_dashboard.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import stock_dashboard as sd
+
+
+def test_safe_section_handles_non_dict():
+    assert sd._safe_section([], "AAPL") == {}
+
+
+def test_safe_section_returns_mapping_for_ticker():
+    data = {"AAPL": {"value": 1}, "MSFT": {"value": 2}}
+    assert sd._safe_section(data, "AAPL") == {"value": 1}
+
+
+def test_resolve_company_name_prefers_quote_type():
+    name = sd.resolve_company_name(
+        "AAPL", quote_type={"longName": "Apple Inc."}, price={"longName": "Price"}
+    )
+    assert name == "Apple Inc."
+
+
+def test_resolve_company_name_uses_price_long_name_when_quote_type_missing():
+    name = sd.resolve_company_name("AAPL", quote_type={}, price={"longName": "Price"})
+    assert name == "Price"
+
+
+def test_resolve_company_name_uses_short_name_then_profile_then_ticker():
+    name = sd.resolve_company_name(
+        "AAPL", quote_type={}, price={"shortName": "Short"}, profile={}
+    )
+    assert name == "Short"
+
+    name_profile = sd.resolve_company_name(
+        "AAPL", quote_type={}, price={}, profile={"longName": "Profile Name"}
+    )
+    assert name_profile == "Profile Name"
+
+    name_fallback = sd.resolve_company_name("AAPL", quote_type={}, price={}, profile={})
+    assert name_fallback == "AAPL"


### PR DESCRIPTION
## Summary
- add resilient company name resolution that falls back across Yahoo sections before defaulting to the ticker
- wrap Streamlit startup in a main() entrypoint so the app is import-safe for testing
- add pytest dependency and unit tests covering safe section handling and company name resolution logic

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952adeebf0483299b47453eb08e4050)