### PR TITLE
Handle yahooquery dataframe responses for ticker data

### DIFF
--- a/stock_dashboard.py
+++ b/stock_dashboard.py
@@ -80,11 +80,21 @@ def get_default_watchlist_string(path: Path | None = None) -> str:
 def _safe_section(section, ticker):
     """Return ticker-specific data when the yahooquery section is a mapping."""
 
-    if not isinstance(section, dict):
+    if isinstance(section, pd.DataFrame):
+        if ticker in section.index:
+            row = section.loc[ticker]
+            if isinstance(row, pd.Series):
+                return row.to_dict()
         return {}
 
-    value = section.get(ticker, {})
-    return value if isinstance(value, dict) else {}
+    if isinstance(section, pd.Series):
+        return section.to_dict() if section.name == ticker else {}
+
+    if hasattr(section, "get"):
+        value = section.get(ticker, {})
+        return value if isinstance(value, dict) else {}
+
+    return {}
 
 
 def resolve_company_name(ticker, quote_type=None, price=None, profile=None):

--- a/tests/test_stock_dashboard.py
+++ b/tests/test_stock_dashboard.py
@@ -10,6 +10,20 @@ def test_safe_section_returns_mapping_for_ticker():
     assert sd._safe_section(data, "AAPL") == {"value": 1}
 
 
+def test_safe_section_handles_dataframe_row():
+    data = sd.pd.DataFrame(
+        [{"value": 1}, {"value": 2}], index=["AAPL", "MSFT"]
+    )
+
+    assert sd._safe_section(data, "AAPL") == {"value": 1}
+
+
+def test_safe_section_handles_series_name_match():
+    series = sd.pd.Series({"value": 3}, name="AAPL")
+
+    assert sd._safe_section(series, "AAPL") == {"value": 3}
+
+
 def test_resolve_company_name_prefers_quote_type():
     name = sd.resolve_company_name(
         "AAPL", quote_type={"longName": "Apple Inc."}, price={"longName": "Price"}
@@ -58,3 +72,74 @@ def test_get_default_watchlist_string_joins_entries(tmp_path, monkeypatch):
     monkeypatch.setattr(sd, "DEFAULT_WATCHLIST_PATH", watchlist_file)
 
     assert sd.get_default_watchlist_string() == "AAPL,ADYEY,AMZN"
+
+
+def test_display_stock_uses_available_values(monkeypatch):
+    captured = {}
+
+    class FakeTicker:
+        def __init__(self, ticker):
+            self.summary_detail = sd.pd.DataFrame(
+                {
+                    "trailingPE": [30],
+                    "priceToBook": [1.5],
+                    "dividendYield": [0.02],
+                    "pegRatio": [1.4],
+                    "priceToSalesTrailing12Months": [2.0],
+                },
+                index=[ticker],
+            )
+            self.financial_data = sd.pd.DataFrame(
+                {
+                    "profitMargins": [0.25],
+                    "returnOnEquity": [0.18],
+                    "currentRatio": [1.8],
+                    "operatingCashflow": [1_000_000_000],
+                    "revenueGrowth": [0.05],
+                    "earningsGrowth": [0.07],
+                    "operatingMargins": [0.12],
+                    "debtToEquity": [50],
+                    "freeCashflow": [500_000_000],
+                    "ebitdaMargins": [0.15],
+                    "returnOnAssets": [0.09],
+                    "totalRevenue": [5_000_000_000],
+                    "totalCash": [1_000_000_000],
+                    "totalDebt": [500_000_000],
+                },
+                index=[ticker],
+            )
+            self.asset_profile = {ticker: {"industry": "Tech", "sector": "IT"}}
+            self.key_stats = sd.pd.DataFrame(
+                {
+                    "marketCap": [2_000_000_000],
+                    "sharesOutstanding": [1_000_000_000],
+                    "revenuePerShare": [5.0],
+                    "enterpriseToEbitda": [10],
+                    "heldPercentInsiders": [0.1],
+                },
+                index=[ticker],
+            )
+            self.quote_type = {ticker: {"longName": "Fake Corp"}}
+            self.price = {ticker: {"shortName": "Fake"}}
+            self._history = sd.pd.DataFrame()
+
+        def history(self, period):
+            return self._history
+
+    def noop(*args, **kwargs):
+        return None
+
+    def capture_dataframe(df, **kwargs):
+        captured["df"] = df
+        return None
+
+    for func in ["subheader", "markdown", "error"]:
+        monkeypatch.setattr(sd.st, func, noop)
+    monkeypatch.setattr(sd.st, "dataframe", capture_dataframe)
+    monkeypatch.setattr(sd, "Ticker", FakeTicker)
+
+    sd.display_stock("AAPL")
+
+    assert "df" in captured
+    # Ensure multiple metrics were rendered with non-placeholder values
+    assert all(value != "N/A" for value in captured["df"]["Value"].head(5))


### PR DESCRIPTION
## Summary
- handle dataframe and series sections from yahooquery so ticker metrics stay populated
- add regression tests to ensure display_stock renders values when data is available

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952b57f858883299a215c9467852e4f)