### PR TITLE
Add validation for missing ticker data

### DIFF
--- a/stock_dashboard.py
+++ b/stock_dashboard.py
@@ -122,6 +122,30 @@ def format_billions(val):
         return f"{val / 1e9:.2f}B"
     return val
 
+
+def ensure_data_available(ticker, sections, metrics):
+    """Validate that required sections and metrics are populated for the ticker."""
+
+    missing_sections = [name for name, data in sections.items() if not data]
+    if missing_sections:
+        joined = ", ".join(missing_sections)
+        raise ValueError(f"No data found for {ticker}: missing sections {joined}.")
+
+    has_metric_value = any(value is not None for value in metrics.values())
+    if not has_metric_value:
+        raise ValueError(f"No metrics available for {ticker} from Yahoo Finance.")
+
+    critical_fields = {
+        "market cap": sections.get("key_stats", {}).get("marketCap"),
+        "total revenue": sections.get("financial_data", {}).get("totalRevenue"),
+        "total debt": sections.get("financial_data", {}).get("totalDebt"),
+    }
+    missing_fields = [name for name, value in critical_fields.items() if value is None]
+    if missing_fields:
+        joined = ", ".join(missing_fields)
+        raise ValueError(f"Missing required fields for {ticker}: {joined}.")
+
+
 def display_stock(ticker):
     t = Ticker(ticker)
     summary = _safe_section(t.summary_detail, ticker)
@@ -131,26 +155,16 @@ def display_stock(ticker):
     quote_type = _safe_section(t.quote_type, ticker)
     price = _safe_section(t.price, ticker)
 
-    industry = profile.get("industry", "—")
-    sector = profile.get("sector", "—")
-    market_cap = format_billions(key_stats.get("marketCap", "—"))
+    sections = {
+        "summary_detail": summary,
+        "financial_data": financial,
+        "asset_profile": profile,
+        "key_stats": key_stats,
+        "price": price,
+    }
+
     total_revenue_val = financial.get("totalRevenue", None)
-    total_revenue = format_billions(total_revenue_val)
-    total_cash = format_billions(financial.get("totalCash", "—"))
-    total_debt = format_billions(financial.get("totalDebt", "—"))
     shares_outstanding_val = key_stats.get("sharesOutstanding", None)
-    shares_outstanding = format_billions(shares_outstanding_val)
-
-    company_name = resolve_company_name(ticker, quote_type, price, profile)
-
-    st.subheader(f"{ticker} - {company_name}")
-    st.markdown(f"**Industry**: {industry}")
-    st.markdown(f"**Sector**: {sector}")
-    st.markdown(f"**Market Cap**: {market_cap}")
-    st.markdown(f"**Total Revenue**: {total_revenue}")
-    st.markdown(f"**Total Cash**: {total_cash}")
-    st.markdown(f"**Total Debt**: {total_debt}")
-    st.markdown(f"**Shares Outstanding**: {shares_outstanding}")
 
     buybacks = None
     try:
@@ -200,6 +214,27 @@ def display_stock(ticker):
         "Insider Ownership (%)": key_stats.get("heldPercentInsiders", None),
         "Buybacks": buybacks
     }
+
+    ensure_data_available(ticker, sections, metrics)
+
+    industry = profile.get("industry", "—")
+    sector = profile.get("sector", "—")
+    market_cap = format_billions(key_stats.get("marketCap", "—"))
+    total_revenue = format_billions(total_revenue_val)
+    total_cash = format_billions(financial.get("totalCash", "—"))
+    total_debt = format_billions(financial.get("totalDebt", "—"))
+    shares_outstanding = format_billions(shares_outstanding_val)
+
+    company_name = resolve_company_name(ticker, quote_type, price, profile)
+
+    st.subheader(f"{ticker} - {company_name}")
+    st.markdown(f"**Industry**: {industry}")
+    st.markdown(f"**Sector**: {sector}")
+    st.markdown(f"**Market Cap**: {market_cap}")
+    st.markdown(f"**Total Revenue**: {total_revenue}")
+    st.markdown(f"**Total Cash**: {total_cash}")
+    st.markdown(f"**Total Debt**: {total_debt}")
+    st.markdown(f"**Shares Outstanding**: {shares_outstanding}")
 
     rows = []
     pass_count = 0

--- a/tests/test_stock_dashboard.py
+++ b/tests/test_stock_dashboard.py
@@ -1,3 +1,5 @@
+import pytest
+
 import stock_dashboard as sd
 
 
@@ -57,6 +59,52 @@ def test_load_watchlist_reads_default_uppercase(tmp_path, monkeypatch):
     monkeypatch.setattr(sd, "DEFAULT_WATCHLIST_PATH", watchlist_file)
 
     assert sd.load_watchlist() == ["AAPL", "MSFT", "NVDA"]
+
+
+def test_ensure_data_available_detects_missing_sections():
+    sections = {
+        "summary_detail": {},
+        "financial_data": {},
+        "asset_profile": {},
+        "key_stats": {},
+        "price": {},
+    }
+
+    with pytest.raises(ValueError) as exc:
+        sd.ensure_data_available("AAPL", sections, {"P/E Ratio": None})
+
+    assert "missing sections" in str(exc.value)
+
+
+def test_ensure_data_available_requires_metrics_and_critical_fields():
+    sections = {
+        "summary_detail": {"trailingPE": 20},
+        "financial_data": {"totalRevenue": None, "totalDebt": None},
+        "asset_profile": {"industry": "Tech"},
+        "key_stats": {"marketCap": None},
+        "price": {"shortName": "Test"},
+    }
+    metrics = {"P/E Ratio": 15.0, "Current Ratio": None}
+
+    with pytest.raises(ValueError) as exc:
+        sd.ensure_data_available("AAPL", sections, metrics)
+
+    assert "Missing required fields" in str(exc.value)
+
+
+def test_ensure_data_available_detects_missing_metrics():
+    sections = {
+        "summary_detail": {"trailingPE": 20},
+        "financial_data": {"totalRevenue": 1, "totalDebt": 1},
+        "asset_profile": {"industry": "Tech"},
+        "key_stats": {"marketCap": 10},
+        "price": {"shortName": "Test"},
+    }
+
+    with pytest.raises(ValueError) as exc:
+        sd.ensure_data_available("AAPL", sections, {"P/E Ratio": None})
+
+    assert "No metrics available" in str(exc.value)
 
 
 def test_get_default_watchlist_string_uses_fallback(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add a reusable `ensure_data_available` helper to validate fetched ticker sections and metrics
- raise descriptive errors when key fundamentals or all metrics are missing so Streamlit can surface failures
- extend unit tests to cover validation scenarios and keep existing display behavior safe

## Testing
- python -m pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952b8405170832991e70e6d72890ca1)