### PR TITLE
Add smoke-test fast path and server health check

### DIFF
--- a/stock_dashboard/ui.py
+++ b/stock_dashboard/ui.py
@@ -126,6 +126,19 @@ def main():
     st.set_page_config(page_title="Value Investing Dashboard", layout="wide")
     st.title("📊 Value Investing Dashboard")
 
+    if data_access.is_smoke_mode():
+        st.info(
+            "Smoke test mode enabled. Skipping live ticker validation and data fetches."
+        )
+        st.markdown(
+            "This lightweight page confirms the server is running without reaching "
+            "out to Yahoo Finance. Disable `SMOKE_TEST` to load live ticker data."
+        )
+        st.markdown(
+            f"Default watchlist: `{data_access.get_default_watchlist_string()}`"
+        )
+        return
+
     default_watchlist = data_access.get_default_watchlist_string()
     ticker_input = st.text_input(
         "Enter comma-separated stock tickers (e.g. AAPL,MSFT,META):",

--- a/tests/test_smoke_mode.py
+++ b/tests/test_smoke_mode.py
@@ -1,0 +1,65 @@
+import os
+from pathlib import Path
+import socket
+import subprocess
+import time
+import urllib.error
+import urllib.request
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("", 0))
+        return sock.getsockname()[1]
+
+
+def _wait_for_ready(url: str, timeout: float = 20.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(url) as response:  # noqa: S310
+                if response.status == 200:
+                    return
+        except (urllib.error.URLError, ConnectionError):
+            time.sleep(0.5)
+            continue
+
+    raise TimeoutError(f"Timed out waiting for {url}")
+
+
+def test_smoke_mode_serves_placeholder(tmp_path):
+    port = _find_free_port()
+    env = os.environ | {
+        "SMOKE_TEST": "1",
+        "STREAMLIT_SERVER_HEADLESS": "true",
+    }
+
+    cmd = [
+        "streamlit",
+        "run",
+        "stock_dashboard.py",
+        "--server.port",
+        str(port),
+        "--server.address",
+        "127.0.0.1",
+    ]
+
+    proc = subprocess.Popen(
+        cmd,
+        cwd=Path(__file__).resolve().parents[1],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+    )
+
+    try:
+        _wait_for_ready(f"http://127.0.0.1:{port}/")
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+
+    assert proc.returncode in (None, 0, -15)


### PR DESCRIPTION
## Summary
- add an SMOKE_TEST fast path to render a lightweight placeholder without contacting Yahoo Finance
- short-circuit ticker validation and section fetches when smoke mode is enabled
- add an automated smoke test that runs the app in smoke mode and verifies the root endpoint responds

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952c87916a0832995f750fba80a3f10)