### PR TITLE
Improve Streamlit health check failure handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,22 @@ jobs:
 
       - name: Verify app responds on dev port
         run: |
-          timeout 30 bash -c 'until curl -sSf http://localhost:8501/ >/dev/null; do sleep 2; done'
+          set -euo pipefail
+
+          if ! timeout 30 bash -c 'until curl -sSf http://localhost:8501/ >/dev/null; do sleep 2; done'; then
+            status=$?
+            echo "Health check failed with status ${status}"
+
+            if [ -f /tmp/streamlit.log ]; then
+              echo "--- Begin Streamlit log ---"
+              cat /tmp/streamlit.log
+              echo "--- End Streamlit log ---"
+            else
+              echo "Streamlit log not found at /tmp/streamlit.log"
+            fi
+
+            exit 1
+          fi
 
       - name: Show Streamlit logs (on failure)
         if: failure()


### PR DESCRIPTION
## Summary
- ensure the Streamlit health check uses strict error handling and exits when the timeout triggers
- print the Streamlit log immediately when the health check fails and rely on artifact upload for failure context

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952c86c47a48329b5f77e86b53f4e1a)