### PR TITLE
Improve Streamlit smoke diagnostics in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,16 +67,13 @@ jobs:
 
       - name: Verify app responds on dev port
         run: |
-          set -euo pipefail
+          set -u
 
-          if ! (
-            set -euo pipefail
+          timeout 30 bash -c 'until curl -sSf http://localhost:8501/ >/dev/null; do sleep 2; done'
+          ready_status=$?
 
-            timeout 30 bash -c 'until curl -sSf http://localhost:8501/ >/dev/null; do sleep 2; done'
-            curl -sSf http://localhost:8501/ >/tmp/streamlit_smoke.html
-          ); then
-            status=$?
-            echo "Health check failed with status ${status}"
+          if [ "${ready_status}" -ne 0 ]; then
+            echo "Readiness check failed with status ${ready_status}"
 
             if [ -f /tmp/streamlit.log ]; then
               echo "--- Begin Streamlit log ---"
@@ -86,13 +83,26 @@ jobs:
               echo "Streamlit log not found at /tmp/streamlit.log"
             fi
 
-            if ps -ef | grep "[s]treamlit"; then
-              echo "Streamlit process is running."
+            ps -ef | grep "[s]treamlit" || true
+            exit 1
+          fi
+
+          curl -sSf http://localhost:8501/ >/tmp/streamlit_smoke.html
+          curl_status=$?
+
+          if [ "${curl_status}" -ne 0 ]; then
+            echo "App fetch failed with status ${curl_status}"
+
+            if [ -f /tmp/streamlit.log ]; then
+              echo "--- Begin Streamlit log ---"
+              cat /tmp/streamlit.log
+              echo "--- End Streamlit log ---"
             else
-              echo "Streamlit process is not running."
+              echo "Streamlit log not found at /tmp/streamlit.log"
             fi
 
-            exit "${status}"
+            ps -ef | grep "[s]treamlit" || true
+            exit 1
           fi
 
       - name: Show Streamlit logs (on failure)


### PR DESCRIPTION
## Summary
- capture readiness and fetch statuses separately in the Streamlit smoke test step
- add inline diagnostics and early exits so failures show logs and process info before stopping

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952d7f824e48329bedfa73f1654963c)