### PR TITLE
Improve Streamlit startup verification in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,45 @@ jobs:
             --browser.gatherUsageStats false \
             >/tmp/streamlit.log 2>&1 &
 
+          sleep 3
+
+          if ! pgrep -f "streamlit run" >/dev/null; then
+            echo "Streamlit process did not start."
+
+            if [ -f /tmp/streamlit.log ]; then
+              echo "--- Begin Streamlit log ---"
+              cat /tmp/streamlit.log
+              echo "--- End Streamlit log ---"
+            else
+              echo "Streamlit log not found at /tmp/streamlit.log"
+            fi
+
+            exit 1
+          fi
+
       - name: Verify app responds on dev port
         run: |
           set -u
+
+          if ! pgrep -f "streamlit run" >/dev/null; then
+            echo "Streamlit process is not running before readiness checks."
+
+            if [ -f /tmp/streamlit.log ]; then
+              echo "--- Begin Streamlit log ---"
+              cat /tmp/streamlit.log
+              echo "--- End Streamlit log ---"
+            else
+              echo "Streamlit log not found at /tmp/streamlit.log"
+            fi
+
+            exit 1
+          fi
+
+          if [ -f /tmp/streamlit.log ]; then
+            echo "--- Recent Streamlit log entries ---"
+            tail -n 40 /tmp/streamlit.log || true
+            echo "--- End recent Streamlit log entries ---"
+          fi
 
           timeout 30 bash -c 'until curl -sSf http://localhost:8501/ >/dev/null; do sleep 2; done'
           ready_status=$?


### PR DESCRIPTION
## Summary
- add a short post-launch sleep and process check to surface early Streamlit startup failures
- tail recent Streamlit log lines before readiness checks to capture startup errors
- guard readiness and final fetch against missing background processes

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952d8b0a4848329b5cab10a8aa19483)