### PR TITLE
Add smoke-mode demo data and render guard

### DIFF
--- a/stock_dashboard/data_access.py
+++ b/stock_dashboard/data_access.py
@@ -178,13 +178,41 @@ def fetch_ticker_sections(ticker: str, ticker_cls: type[Ticker] = Ticker) -> dic
 
     if is_smoke_mode():
         return {
-            "summary_detail": {},
-            "financial_data": {},
-            "asset_profile": {},
-            "key_stats": {},
-            "quote_type": {"symbol": ticker, "longName": f"{ticker} (smoke mode)"},
-            "price": {"shortName": ticker},
-            "buybacks": None,
+            "summary_detail": {
+                "trailingPE": 15.0,
+                "priceToBook": 2.1,
+                "priceToSalesTrailing12Months": 4.2,
+                "dividendYield": 0.012,
+                "pegRatio": 1.3,
+            },
+            "financial_data": {
+                "profitMargins": 0.22,
+                "returnOnEquity": 0.17,
+                "currentRatio": 2.1,
+                "quickRatio": 1.6,
+                "revenueGrowth": 0.07,
+                "earningsGrowth": 0.06,
+                "operatingMargins": 0.14,
+                "debtToEquity": 42.0,
+                "freeCashflow": 3.2e10,
+                "operatingCashflow": 4.5e10,
+                "totalRevenue": 2.4e11,
+                "totalDebt": 5.5e10,
+            },
+            "asset_profile": {"industry": "Demo Software", "sector": "Technology"},
+            "key_stats": {
+                "marketCap": 1.6e12,
+                "sharesOutstanding": 1.6e10,
+                "revenuePerShare": 14.5,
+                "enterpriseToEbitda": 14.0,
+                "heldPercentInsiders": 0.08,
+            },
+            "quote_type": {
+                "symbol": ticker,
+                "longName": f"{ticker} Demo Corp",
+            },
+            "price": {"shortName": f"{ticker} Demo"},
+            "buybacks": True,
         }
 
     ticker_client = ticker_cls(ticker)

--- a/stock_dashboard/ui.py
+++ b/stock_dashboard/ui.py
@@ -126,6 +126,8 @@ def main():
     st.set_page_config(page_title="Value Investing Dashboard", layout="wide")
     st.title("📊 Value Investing Dashboard")
 
+    default_watchlist = data_access.get_default_watchlist_string()
+
     if data_access.is_smoke_mode():
         st.info(
             "Smoke test mode enabled. Skipping live ticker validation and data fetches."
@@ -134,12 +136,8 @@ def main():
             "This lightweight page confirms the server is running without reaching "
             "out to Yahoo Finance. Disable `SMOKE_TEST` to load live ticker data."
         )
-        st.markdown(
-            f"Default watchlist: `{data_access.get_default_watchlist_string()}`"
-        )
-        return
 
-    default_watchlist = data_access.get_default_watchlist_string()
+    st.markdown(f"Default watchlist: `{default_watchlist}`")
     ticker_input = st.text_input(
         "Enter comma-separated stock tickers (e.g. AAPL,MSFT,META):",
         default_watchlist,

--- a/tests/test_streamlit_render.py
+++ b/tests/test_streamlit_render.py
@@ -1,0 +1,75 @@
+import os
+from pathlib import Path
+import socket
+import subprocess
+import time
+import urllib.error
+import urllib.request
+
+from stock_dashboard import ui
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("", 0))
+        return sock.getsockname()[1]
+
+
+def _wait_for_ready(url: str, timeout: float = 20.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(url) as response:  # noqa: S310
+                if response.status == 200:
+                    return
+        except (urllib.error.URLError, ConnectionError):
+            time.sleep(0.5)
+            continue
+
+    raise TimeoutError(f"Timed out waiting for {url}")
+
+
+def test_streamlit_renders_stub_ticker(tmp_path, monkeypatch, streamlit_spy):
+    port = _find_free_port()
+    env = os.environ | {
+        "SMOKE_TEST": "1",
+        "STREAMLIT_SERVER_HEADLESS": "true",
+    }
+
+    cmd = [
+        "streamlit",
+        "run",
+        "stock_dashboard.py",
+        "--server.port",
+        str(port),
+        "--server.address",
+        "127.0.0.1",
+    ]
+
+    proc = subprocess.Popen(
+        cmd,
+        cwd=Path(__file__).resolve().parents[1],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+    )
+
+    try:
+        _wait_for_ready(f"http://127.0.0.1:{port}/")
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+
+    assert proc.returncode in (None, 0, -15)
+    monkeypatch.setenv("SMOKE_TEST", "1")
+
+    ui.display_stock("AAPL")
+
+    captured = streamlit_spy
+    assert "df" in captured
+    # Ensure rendered values are not placeholders when using demo data
+    assert any(value != "N/A" for value in captured["df"]["Value"].head(3))


### PR DESCRIPTION
## Summary
- add realistic stub data for smoke mode to keep ticker rendering alive without Yahoo Finance
- always render the watchlist even in smoke mode so the app surfaces demo ticker data
- add CI test to ensure the Streamlit server responds and a smoke ticker renders metrics

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952da9aa5108329a158d7740f351717)