### PR TITLE
Add tests for market cap fallbacks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,6 +150,123 @@ def partial_ticker_cls():
 
 
 @pytest.fixture
+def price_cap_ticker_cls():
+    """Ticker class fixture with market cap only in the price section."""
+
+    class PriceCapTicker:
+        def __init__(self, ticker):
+            self.summary_detail = pd.DataFrame(
+                {
+                    "trailingPE": [22.5],
+                    "priceToBook": [3.0],
+                    "dividendYield": [0.015],
+                    "pegRatio": [1.2],
+                    "priceToSalesTrailing12Months": [2.5],
+                },
+                index=[ticker],
+            )
+            self.financial_data = pd.DataFrame(
+                {
+                    "profitMargins": [0.21],
+                    "returnOnEquity": [0.16],
+                    "currentRatio": [1.7],
+                    "quickRatio": [1.4],
+                    "operatingCashflow": [2_500_000_000],
+                    "revenueGrowth": [0.08],
+                    "earningsGrowth": [0.09],
+                    "operatingMargins": [0.13],
+                    "debtToEquity": [60],
+                    "freeCashflow": [750_000_000],
+                    "ebitdaMargins": [0.17],
+                    "returnOnAssets": [0.11],
+                    "totalRevenue": [6_000_000_000],
+                    "totalCash": [1_200_000_000],
+                    "totalDebt": [900_000_000],
+                },
+                index=[ticker],
+            )
+            self.asset_profile = {ticker: {"industry": "Finance", "sector": "Banking"}}
+            self.key_stats = pd.DataFrame(
+                {
+                    "marketCap": [None],
+                    "sharesOutstanding": [[1_000_000_000, 900_000_000]],
+                    "revenuePerShare": [6.0],
+                    "enterpriseToEbitda": [11],
+                    "heldPercentInsiders": [0.06],
+                    "pegRatio": [1.2],
+                },
+                index=[ticker],
+            )
+            self.quote_type = {ticker: {"longName": "Price Cap Corp"}}
+            self.price = {ticker: {"shortName": "PriceCap", "marketCap": 3_500_000_000}}
+            self._history = pd.DataFrame({"close": [1, 2]})
+
+        def history(self, period):
+            return self._history
+
+    return PriceCapTicker
+
+
+@pytest.fixture
+def summary_detail_cap_ticker_cls():
+    """Ticker class fixture with market cap only in summary detail."""
+
+    class SummaryDetailCapTicker:
+        def __init__(self, ticker):
+            self.summary_detail = pd.DataFrame(
+                {
+                    "trailingPE": [18.0],
+                    "priceToBook": [2.2],
+                    "dividendYield": [0.01],
+                    "pegRatio": [1.1],
+                    "priceToSalesTrailing12Months": [2.1],
+                    "marketCap": [4_200_000_000],
+                },
+                index=[ticker],
+            )
+            self.financial_data = pd.DataFrame(
+                {
+                    "profitMargins": [0.2],
+                    "returnOnEquity": [0.14],
+                    "currentRatio": [1.9],
+                    "quickRatio": [1.5],
+                    "operatingCashflow": [3_000_000_000],
+                    "revenueGrowth": [0.06],
+                    "earningsGrowth": [0.05],
+                    "operatingMargins": [0.12],
+                    "debtToEquity": [55],
+                    "freeCashflow": [800_000_000],
+                    "ebitdaMargins": [0.16],
+                    "returnOnAssets": [0.1],
+                    "totalRevenue": [7_500_000_000],
+                    "totalCash": [1_500_000_000],
+                    "totalDebt": [850_000_000],
+                },
+                index=[ticker],
+            )
+            self.asset_profile = {ticker: {"industry": "Energy", "sector": "Utilities"}}
+            self.key_stats = pd.DataFrame(
+                {
+                    "marketCap": [None],
+                    "sharesOutstanding": [[1_200_000_000, 1_000_000_000]],
+                    "revenuePerShare": [6.25],
+                    "enterpriseToEbitda": [9],
+                    "heldPercentInsiders": [0.04],
+                    "pegRatio": [1.1],
+                },
+                index=[ticker],
+            )
+            self.quote_type = {ticker: {"longName": "Summary Cap Corp"}}
+            self.price = {ticker: {"shortName": "SummaryCap"}}
+            self._history = pd.DataFrame({"close": [1, 2]})
+
+        def history(self, period):
+            return self._history
+
+    return SummaryDetailCapTicker
+
+
+@pytest.fixture
 def empty_ticker_cls():
     """Ticker class fixture that returns empty sections for failure testing."""
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -47,3 +47,22 @@ def test_ensure_data_available_detects_missing_metrics():
         metrics.ensure_data_available("AAPL", sections, {"P/E Ratio": None})
 
     assert "No metrics available" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "market_cap_section, fallback_value",
+    [("price", {"price": {"marketCap": 1_500_000_000}}), ("summary_detail", {"summary_detail": {"marketCap": 2_250_000_000}})],
+)
+def test_ensure_data_available_accepts_market_cap_fallback(market_cap_section, fallback_value):
+    base_sections = {
+        "summary_detail": {"trailingPE": 21.0},
+        "financial_data": {"totalRevenue": 10_000_000_000, "totalDebt": 5_000_000_000},
+        "asset_profile": {"industry": "Tech"},
+        "key_stats": {"marketCap": None},
+        "price": {"shortName": "Test"},
+    }
+    base_sections[market_cap_section].update(fallback_value.get(market_cap_section, {}))
+
+    warnings = metrics.ensure_data_available("AAPL", base_sections, {"P/E Ratio": 20.0})
+
+    assert not warnings.get("missing_fields")

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -13,6 +13,28 @@ def test_display_stock_uses_available_values(streamlit_spy, fake_ticker_cls):
     assert all(value != "N/A" for value in captured["df"]["Value"].head(5))
 
 
+def test_display_stock_falls_back_to_price_market_cap(
+    streamlit_spy, price_cap_ticker_cls
+):
+    captured = streamlit_spy
+
+    ui.display_stock("PCAP", ticker_cls=price_cap_ticker_cls)
+
+    assert "df" in captured
+    assert not any("missing required fields" in msg.lower() for msg in captured["warnings"])
+
+
+def test_display_stock_falls_back_to_summary_detail_market_cap(
+    streamlit_spy, summary_detail_cap_ticker_cls
+):
+    captured = streamlit_spy
+
+    ui.display_stock("SCAP", ticker_cls=summary_detail_cap_ticker_cls)
+
+    assert "df" in captured
+    assert not any("missing required fields" in msg.lower() for msg in captured["warnings"])
+
+
 def test_display_stock_allows_partial_data_with_warnings(streamlit_spy, partial_ticker_cls):
     captured = streamlit_spy
 


### PR DESCRIPTION
## Summary
- add fixtures that place market cap in price or summary detail sections while omitting it from key stats
- verify metrics validation accepts market cap fallbacks without flagging missing required fields
- confirm UI rendering avoids missing field warnings when market cap is supplied via fallback sections

## Testing
- pytest tests/test_metrics.py tests/test_ui.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952f8fed24c8329ad747e0bd2fa285b)