### PR TITLE
Update Streamlit dataframe width API

### DIFF
--- a/stock_dashboard/ui.py
+++ b/stock_dashboard/ui.py
@@ -111,7 +111,7 @@ def display_stock(ticker: str, ticker_cls=None):
     st.markdown(f"**Shares Outstanding**: {shares_outstanding}")
 
     df, pass_count, red_count = _render_metric_rows(metrics)
-    st.dataframe(df, use_container_width=True)
+    st.dataframe(df, width="stretch")
 
     score = f"{pass_count} ✅ / {red_count} ❌"
     st.markdown(f"### Snapshot Score: {score}")


### PR DESCRIPTION
## Summary
- replace deprecated `use_container_width=True` with `width="stretch"` for the stock metrics table
- start the Streamlit app to confirm it runs without the deprecation warning

## Testing
- STREAMLIT_SERVER_HEADLESS=true streamlit run stock_dashboard.py --server.port 8501 --server.headless true --server.fileWatcherType none --browser.gatherUsageStats false


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952fc6612e8832988b3c6d41e1ce9af)