### PR TITLE
Handle data fetch errors and surface reasons

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -283,3 +283,31 @@ def empty_ticker_cls():
             return pd.DataFrame()
 
     return EmptyTicker
+
+
+@pytest.fixture
+def erroring_ticker_cls():
+    """Ticker class fixture that raises when fetching sections."""
+
+    class RateLimitError(Exception):
+        def __init__(self, message="Rate limit exceeded", status_code=429):
+            super().__init__(message)
+            self.response = type("Response", (), {"status_code": status_code})()
+
+    class ErrorTicker:
+        def __init__(self, ticker):
+            self.ticker = ticker
+            self.financial_data = {}
+            self.asset_profile = {}
+            self.key_stats = {}
+            self.quote_type = {}
+            self.price = {}
+
+        @property
+        def summary_detail(self):
+            raise RateLimitError()
+
+        def history(self, period):
+            return pd.DataFrame()
+
+    return ErrorTicker

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -61,3 +61,22 @@ def test_watchlist_entries_fail_fast(stubbed_streamlit, empty_ticker_cls):
     for ticker in tickers:
         with pytest.raises(ValueError):
             ui.display_stock(ticker, ticker_cls=empty_ticker_cls)
+
+
+def test_display_stock_surfaces_error_reason(streamlit_spy, erroring_ticker_cls):
+    with pytest.raises(ValueError) as excinfo:
+        ui.display_stock("ERR", ticker_cls=erroring_ticker_cls)
+
+    message = str(excinfo.value)
+    assert "reason" in message
+    assert "429" in message or "Rate limit exceeded" in message
+    assert not streamlit_spy["warnings"]
+
+
+def test_display_stock_warns_when_no_error_details(streamlit_spy, empty_ticker_cls):
+    with pytest.raises(ValueError) as excinfo:
+        ui.display_stock("AAPL", ticker_cls=empty_ticker_cls)
+
+    message = str(excinfo.value)
+    assert "reason" in message
+    assert any("Yahoo Finance" in warning or "outage" in warning for warning in streamlit_spy["warnings"])


### PR DESCRIPTION
## Summary
- capture yahooquery fetch errors and record status/message alongside sections
- surface detailed reasons in UI when no data is returned and add warnings for empty sections without explicit errors
- extend tests for error handling, warning behavior, and data fetch failures

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952fcccf86c8329b1f8dcc90e244d95)