### PR TITLE
Handle Yahoo Finance rate limits with structured errors

### DIFF
--- a/stock_dashboard/__init__.py
+++ b/stock_dashboard/__init__.py
@@ -10,6 +10,7 @@ from .data_access import (
     fetch_ticker_sections,
     get_default_watchlist_string,
     load_watchlist,
+    RateLimitError,
     resolve_company_name,
 )
 from .metrics import (
@@ -38,6 +39,7 @@ __all__ = [
     "main",
     "metrics",
     "pd",
+    "RateLimitError",
     "resolve_company_name",
     "st",
     "thresholds",

--- a/stock_dashboard/ui.py
+++ b/stock_dashboard/ui.py
@@ -58,6 +58,21 @@ def display_stock(ticker: str, ticker_cls=None):
     sections = data_access.fetch_ticker_sections(ticker, ticker_cls=ticker_cls)
 
     error_info = sections.get("error") or {}
+    rate_limit = error_info.get("rate_limit")
+    if isinstance(rate_limit, data_access.RateLimitError):
+        remaining_seconds = rate_limit.remaining or rate_limit.retry_after or 0
+        host = rate_limit.host or "Yahoo Finance"
+        message = (
+            f"Rate limit detected from {host}. Please wait {remaining_seconds} seconds before retrying."
+        )
+        st.info(message)
+        try:
+            st.toast(message)
+        except Exception:
+            # Toast not available in some Streamlit versions; banner is sufficient.
+            pass
+        return
+
     core_sections = {
         k: v for k, v in sections.items() if k not in {"buybacks", "error"}
     }

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -64,16 +64,19 @@ def test_watchlist_entries_fail_fast(stubbed_streamlit, empty_ticker_cls):
 
 
 def test_display_stock_surfaces_error_reason(streamlit_spy, erroring_ticker_cls):
-    with pytest.raises(ValueError) as excinfo:
-        ui.display_stock("ERR", ticker_cls=erroring_ticker_cls)
+    data_access.RATE_LIMIT_COOLDOWNS.clear()
+    captured = streamlit_spy
 
-    message = str(excinfo.value)
-    assert "reason" in message
-    assert "429" in message or "Rate limit exceeded" in message
-    assert not streamlit_spy["warnings"]
+    ui.display_stock("ERR", ticker_cls=erroring_ticker_cls)
+
+    assert any("Rate limit" in message for message in captured["info"])
+    assert not captured["warnings"]
+    data_access.RATE_LIMIT_COOLDOWNS.clear()
 
 
 def test_display_stock_warns_when_no_error_details(streamlit_spy, empty_ticker_cls):
+    data_access.RATE_LIMIT_COOLDOWNS.clear()
+
     with pytest.raises(ValueError) as excinfo:
         ui.display_stock("AAPL", ticker_cls=empty_ticker_cls)
 


### PR DESCRIPTION
## Summary
- capture yahooquery response metadata into structured `RateLimitError` objects and track host-level cooldowns
- surface rate-limit signals through `fetch_ticker_sections` into the Streamlit UI with a dedicated banner and cooldown skip logic
- add telemetry logging plus tests covering rate-limit parsing and UI handling

## Testing
- python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953004234c48329a602228b9dc252e3)