### PR TITLE
Restrict CI triggers and add concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,10 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches:
+      - "main"
+    tags:
+      - "v*"
     paths:
       - "stock_dashboard/**"
       - "stock_dashboard.py"
@@ -12,7 +15,8 @@ on:
       - ".github/workflows/**"
       - "watchlist.txt"
   pull_request:
-    branches: ["**"]
+    branches:
+      - "**"
     paths:
       - "stock_dashboard/**"
       - "stock_dashboard.py"
@@ -22,6 +26,10 @@ on:
       - ".github/workflows/**"
       - "watchlist.txt"
   workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint-and-test:


### PR DESCRIPTION
## Summary
- limit push triggers to main and release tags while keeping pull request coverage for feature branches
- add workflow concurrency to cancel redundant runs on the same ref

## Testing
- Not run (not needed)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69530ade91ec83298d6ed71c1084165c)