### PR TITLE
Add import and streamlit startup smoke tests

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -11,7 +11,6 @@ import pytest
 STREAMLIT_CLI = shutil.which("streamlit")
 
 
-@pytest.mark.skipif(STREAMLIT_CLI is None, reason="Streamlit CLI not available")
 def test_module_exports_core_attributes():
     import stock_dashboard as module
 


### PR DESCRIPTION
## Summary
- add an import test to verify stock_dashboard exposes core modules
- add a Streamlit CLI startup smoke test gated for missing binaries or port binding issues

## Testing
- pytest tests/test_imports.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69530af1b87c8329ab91cd75830d376c)