### PR TITLE
Add import and headless bootstrap tests

### DIFF
--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,59 @@
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import time
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STREAMLIT_CLI = shutil.which("streamlit")
+
+
+@pytest.mark.skipif(STREAMLIT_CLI is None, reason="Streamlit CLI not available")
+def test_headless_bootstrap_startup(tmp_path):
+    log_path = tmp_path / "streamlit_bootstrap.log"
+    env = os.environ | {
+        "SMOKE_TEST": "1",
+        "STREAMLIT_SERVER_HEADLESS": "true",
+        "STREAMLIT_BROWSER_GATHERUSAGESTATS": "false",
+    }
+
+    cmd = [
+        STREAMLIT_CLI,
+        "run",
+        str(REPO_ROOT / "stock_dashboard.py"),
+        "--server.headless",
+        "true",
+        "--server.port",
+        "0",
+        "--server.address",
+        "127.0.0.1",
+        "--browser.gatherUsageStats",
+        "false",
+    ]
+
+    with log_path.open("wb") as log_file:
+        proc = subprocess.Popen(
+            cmd,
+            cwd=REPO_ROOT,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            env=env,
+        )
+
+        try:
+            time.sleep(5)
+            assert proc.poll() is None, log_path.read_text()
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+
+    if log_path.exists():
+        log_contents = log_path.read_text().strip()
+        assert "Traceback" not in log_contents

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,18 @@
+import importlib
+
+
+EXPECTED_ATTRIBUTES = [
+    "data_access",
+    "metrics",
+    "ui",
+    "main",
+]
+
+
+def test_package_exports_expected_members():
+    module = importlib.import_module("stock_dashboard")
+
+    for attr in EXPECTED_ATTRIBUTES:
+        assert hasattr(module, attr), f"Missing attribute: {attr}"
+
+    assert callable(module.main)


### PR DESCRIPTION
## Summary
- add a package import test to verify key stock_dashboard attributes are available
- add a headless Streamlit bootstrap test that exercises SMOKE_TEST startup in CI while skipping when Streamlit is missing

## Testing
- python -m pytest --maxfail=1


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953163652188329a9d0f91bc73046c7)