### PR TITLE
Add CLI for ticker metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ streamlit run stock_dashboard.py
 - Install dev tools: `pip install -r requirements-dev.txt`
 - Run linting: `ruff check .`
 - Run tests: `pytest`
+- Run the CLI headlessly (no Streamlit UI): `python -m stock_dashboard.cli --tickers AAPL,MSFT --verbose`
+- Deterministic CI/smoke runs: set `SMOKE_TEST=1` to use stubbed data and `YF_DISABLE_CACHE=1` to disable caching, e.g. `SMOKE_TEST=1 YF_DISABLE_CACHE=1 python -m stock_dashboard.cli --tickers AAPL`
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,13 @@
+[project]
+name = "value-dashboard"
+version = "0.0.0"
+description = "Value investing dashboard"
+readme = "README.md"
+requires-python = ">=3.9"
+
+[project.scripts]
+stock-dashboard = "stock_dashboard.cli:main"
+
 [tool.ruff]
 target-version = "py39"
 line-length = 100

--- a/stock_dashboard/__main__.py
+++ b/stock_dashboard/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for running the dashboard package as a module."""
+
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover - invoked via -m
+    main()

--- a/stock_dashboard/cli.py
+++ b/stock_dashboard/cli.py
@@ -1,0 +1,106 @@
+"""Command-line interface for fetching ticker data and computing metrics."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from typing import Iterable, Sequence
+
+from . import data_access, metrics
+
+LOGGER = logging.getLogger(__name__)
+
+
+_DEF_EXCLUDED_SECTION_KEYS = {"buybacks", "error", "cache_info"}
+
+
+def _parse_tickers(raw: str) -> list[str]:
+    tickers = [ticker.strip() for ticker in raw.split(",") if ticker.strip()]
+    return tickers
+
+
+def _normalized_sections(
+    sections: dict[str, dict[str, object]]
+) -> dict[str, dict[str, object]]:
+    return {k: v for k, v in sections.items() if k not in _DEF_EXCLUDED_SECTION_KEYS}
+
+
+def _configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="[%(levelname)s] %(message)s")
+
+
+def _process_ticker(ticker: str, ticker_client: object | None = None) -> bool:
+    try:
+        LOGGER.info("Fetching sections for %s", ticker)
+        sections = data_access.fetch_ticker_sections(
+            ticker, ticker_client=ticker_client
+        )
+
+        computed_metrics = metrics.compute_metrics(ticker, sections)
+        warnings = metrics.ensure_data_available(
+            ticker, _normalized_sections(sections), computed_metrics
+        )
+    except ValueError as exc:  # noqa: BLE001
+        LOGGER.error("%s", exc)
+        return False
+
+    for category, missing_items in warnings.items():
+        LOGGER.warning("%s: %s", category, ", ".join(sorted(missing_items)))
+
+    LOGGER.info("Computed %d metrics for %s", len(computed_metrics), ticker)
+    return True
+
+
+def run(tickers: Iterable[str]) -> int:
+    normalized = [ticker for ticker in tickers if ticker]
+    validated = data_access.validate_tickers(normalized)
+
+    if not validated:
+        LOGGER.error("No valid tickers supplied after validation")
+        return 1
+
+    shared_client = data_access.get_batched_ticker_client(validated)
+
+    failures = 0
+    for ticker in validated:
+        ok = _process_ticker(ticker, ticker_client=shared_client)
+        failures += int(not ok)
+
+    if failures:
+        LOGGER.error("Completed with %d validation failure(s)", failures)
+        return 1
+
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Compute value-investing metrics for tickers",
+    )
+    parser.add_argument(
+        "--tickers",
+        required=True,
+        help="Comma-separated ticker symbols (e.g., AAPL,MSFT)",
+        type=_parse_tickers,
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    _configure_logging(args.verbose)
+    exit_code = run(args.tickers)
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a command-line interface to compute ticker sections and metrics with validation
- expose module and console entrypoints for headless execution
- document CLI usage along with smoke-mode and cache-disabling flags for CI determinism

## Testing
- SMOKE_TEST=1 python -m stock_dashboard.cli --tickers AAPL,MSFT --verbose

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953210fb7448329b57fc90607cbd479)