### PR TITLE
Fix PR discovery job to specify repository

### DIFF
--- a/.github/workflows/auto-rebase-prs.yml
+++ b/.github/workflows/auto-rebase-prs.yml
@@ -27,7 +27,7 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.repository }}
         run: |
-          prs=$(gh pr list --state open --json number,headRefName,headRepositoryOwner --jq \
+          prs=$(gh pr list --repo "$REPO" --state open --json number,headRefName,headRepositoryOwner --jq \
             '[.[] | select(.headRepositoryOwner.login == env.OWNER) | {number: .number, branch: .headRefName}]')
 
           if [ -z "$prs" ]; then


### PR DESCRIPTION
## Summary
- update PR discovery step to specify the repository when invoking `gh pr list`
- avoid git repository requirement during workflow execution

## Testing
- not run (CI workflow only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695428eb61708329aacee6a450027c20)