### PR TITLE
Handle Streamlit chip_select state locking

### DIFF
--- a/stock_dashboard/ui.py
+++ b/stock_dashboard/ui.py
@@ -315,7 +315,7 @@ def main():
         with selection_tab:
             col_select, col_actions = st.columns([1.5, 1], gap="medium")
             with col_select:
-                st.session_state.chip_select = st.multiselect(
+                st.multiselect(
                     "Quick select (recent & defaults):",
                     all_options,
                     default=st.session_state.watchlist,


### PR DESCRIPTION
## Summary
- extend the Streamlit test double to lock chip_select after multiselect instantiation
- remove manual chip_select reassignment in the watchlist UI and cover the regression with a new test
- keep watchlist selections flowing through to ticker display under the stricter session state behavior

## Testing
- python -m pytest tests/test_watchlist_form.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695577873fb083299cb5c909acd31fb6)