### PR TITLE
Add deployment permissions for dev deploy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,9 @@ jobs:
     name: Dev deploy smoke
     needs: lint-and-test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
     environment: dev
     env:
       PYTHON_VERSION: '3.11'


### PR DESCRIPTION
## Summary
- grant the dev deploy job permissions to update deployment statuses

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695593d5183c8329bbf97639d5e17034)