### PR TITLE
Add coverage reporting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,15 @@ jobs:
       - name: Run tests
         run: |
           source .venv/bin/activate
-          pytest
+          pytest --cov=stock_dashboard --cov-report=xml --cov-fail-under=75
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
+          if-no-files-found: ignore
 
   dev-deploy:
     name: Dev deploy smoke

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,11 @@ force-single-line = false
 testpaths = ["tests"]
 addopts = "-ra"
 pythonpath = ["."]
+
+[tool.coverage.run]
+branch = true
+source = ["stock_dashboard"]
+
+[tool.coverage.report]
+fail_under = 75
+show_missing = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 mypy
 ruff
 pre-commit
+pytest-cov


### PR DESCRIPTION
## Summary
- add pytest-cov to development dependencies and configure coverage defaults
- enforce coverage thresholds when running pytest and generate XML reports
- upload the coverage report from the lint-and-test workflow for PR visibility

## Testing
- pytest --cov=stock_dashboard --cov-report=xml --cov-fail-under=75


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956b02a4620832983e98721ef8b3f3f)