### PR TITLE
Add CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"


### PR DESCRIPTION
## Summary
- add a CodeQL GitHub Actions workflow for Python that runs on pushes and pull requests to main
- initialize CodeQL, perform autobuild, and upload analysis results to GitHub code scanning

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956b20beab88329aa910503aa58e39d)