### PR TITLE
Add Yahoo Finance health probe and gating

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 mypy
+types-requests
 ruff
 pre-commit
 pytest-cov

--- a/stock_dashboard/cli.py
+++ b/stock_dashboard/cli.py
@@ -60,6 +60,20 @@ def run(tickers: Iterable[str]) -> int:
         LOGGER.error("No valid tickers supplied after validation")
         return 1
 
+    health_status = data_access.check_data_source_health()
+    if not health_status.ok:
+        LOGGER.error(
+            "Data source unhealthy: %s", health_status.message or "health check failed"
+        )
+        if health_status.rate_limit:
+            LOGGER.error(
+                "Rate limit active for %s (retry_after=%s)",
+                health_status.rate_limit.host,
+                health_status.rate_limit.retry_after
+                or health_status.rate_limit.remaining,
+            )
+        return 1
+
     shared_client = data_access.get_batched_ticker_client(validated)
 
     failures = 0


### PR DESCRIPTION
## Summary
- add a cached Yahoo Finance health probe with latency and rate-limit metadata
- gate the Streamlit dashboard and CLI on the health probe and show status banners
- pass health diagnostics into ticker rendering for richer troubleshooting

## Testing
- python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956b62721288329a2ebc446213c0644)