### PR TITLE
Relax Yahoo health-check gating on transient rate limits

### DIFF
--- a/stock_dashboard/cli.py
+++ b/stock_dashboard/cli.py
@@ -62,17 +62,18 @@ def run(tickers: Iterable[str]) -> int:
 
     health_status = data_access.check_data_source_health()
     if not health_status.ok:
-        LOGGER.error(
-            "Data source unhealthy: %s", health_status.message or "health check failed"
-        )
         if health_status.rate_limit:
-            LOGGER.error(
-                "Rate limit active for %s (retry_after=%s)",
+            LOGGER.warning(
+                "Data source health check hit rate limit for %s (retry_after=%s); continuing with per-ticker fetch.",
                 health_status.rate_limit.host,
                 health_status.rate_limit.retry_after
                 or health_status.rate_limit.remaining,
             )
-        return 1
+        else:
+            LOGGER.error(
+                "Data source unhealthy: %s", health_status.message or "health check failed"
+            )
+            return 1
 
     shared_client = data_access.get_batched_ticker_client(validated)
 

--- a/stock_dashboard/data_access.py
+++ b/stock_dashboard/data_access.py
@@ -22,6 +22,7 @@ _DEFAULT_PRICE_TTL_SECONDS = int(os.getenv("YF_PRICE_TTL_SECONDS", "300"))
 _CACHE_DISABLE_ENV_VAR = "YF_DISABLE_CACHE"
 _HEALTH_CHECK_CACHE_TTL_SECONDS = 15
 _HEALTH_CHECK_KEY = "yahoo_finance"
+_HEALTH_CHECK_HOSTS = ("query1.finance.yahoo.com", "query2.finance.yahoo.com")
 
 logger = logging.getLogger(__name__)
 VALIDATE_TICKER_CACHE: dict[tuple[type[Any], tuple[str, ...]], list[str]] = {}
@@ -424,15 +425,39 @@ def check_data_source_health(
         _set_cached_health(status)
         return status
 
-    url = "https://query1.finance.yahoo.com/v7/finance/quote"
     params = {"symbols": ticker}
-    start = time.perf_counter()
+
+    responses: list[tuple[str, Any, float]] = []
+    for host in _HEALTH_CHECK_HOSTS:
+        url = f"https://{host}/v7/finance/quote"
+        start = time.perf_counter()
+        try:
+            response = requests.get(url, params=params, timeout=timeout)
+        except requests.Timeout:
+            continue
+        except Exception:
+            continue
+        latency_ms = (time.perf_counter() - start) * 1000
+        responses.append((host, response, latency_ms))
+        if response.status_code < 500 and response.status_code != 429:
+            break
+
+    if not responses:
+        status = DataSourceHealth(
+            ok=False,
+            host=None,
+            latency_ms=None,
+            headers={},
+            message=f"Health check timed out after {timeout}s",
+        )
+        _set_cached_health(status)
+        return status
+
+    host_hint, response, latency_ms = responses[-1]
 
     try:
-        response = requests.get(url, params=params, timeout=timeout)
-        latency_ms = (time.perf_counter() - start) * 1000
         headers = _normalize_headers(response.headers)
-        host = _extract_host(response)
+        host = _extract_host(response) or host_hint
         retry_after = _parse_retry_after(headers)
         rate_limit_error: RateLimitError | None = None
 
@@ -446,7 +471,6 @@ def check_data_source_health(
                 payload=None,
                 remaining=retry_after,
             )
-            _record_rate_limit(rate_limit_error)
 
         ok = response.status_code < 500 and not rate_limit_error
         message = None if response.ok else f"HTTP {response.status_code}"
@@ -457,14 +481,6 @@ def check_data_source_health(
             headers=_rate_limit_headers(headers),
             rate_limit=rate_limit_error,
             message=message,
-        )
-    except requests.Timeout:
-        status = DataSourceHealth(
-            ok=False,
-            host=None,
-            latency_ms=None,
-            headers={},
-            message=f"Health check timed out after {timeout}s",
         )
     except Exception as exc:  # noqa: BLE001
         status = DataSourceHealth(


### PR DESCRIPTION
### Motivation
- Health probe 429 responses from Yahoo were being treated as hard outages and writing global cooldowns that prevented all ticker fetches for extended periods. 
- The goal is to avoid blocking per-ticker fetches for transient/probe-only rate limits and allow recovery or partial success.

### Description
- Added `_HEALTH_CHECK_HOSTS = ("query1.finance.yahoo.com", "query2.finance.yahoo.com")` and updated `check_data_source_health` to probe both hosts in sequence and pick a best-response host instead of only calling `query1`.
- Health probe now aggregates probe responses and uses a `host_hint` when the probe returned a usable host, and it no longer records a global rate-limit cooldown during the health probe (removed `_record_rate_limit` from the probe path).
- Adjusted CLI behavior in `run` so that when `check_data_source_health` reports a rate-limit the CLI logs a warning and continues to attempt per-ticker fetches instead of exiting, while non-rate-limit health failures still fail fast.
- Files changed: `stock_dashboard/data_access.py` and `stock_dashboard/cli.py` (small control-flow and logging changes).

### Testing
- Ran targeted tests: `pytest -q tests/test_data_access.py::test_fetch_ticker_sections_detects_rate_limit tests/test_ui.py::test_display_stock_surfaces_rate_limit_details tests/test_ui.py::test_display_stock_surfaces_error_reason` and they passed (3 passed).
- Ran full test suite with `pytest -q` and all tests passed: `42 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd05edf5608329890ccad900a6a160)