### PR TITLE
Allow per-ticker fetches when Yahoo health probe is throttled

### DIFF
--- a/stock_dashboard/ui.py
+++ b/stock_dashboard/ui.py
@@ -495,7 +495,8 @@ def main():
 
     bypass_health_gate = bool(os.getenv("PYTEST_CURRENT_TEST"))
 
-    if not health_status.ok:
+    has_rate_limit_signal = bool(health_status.rate_limit)
+    if not health_status.ok and not has_rate_limit_signal:
         queued_message = "Skipping ticker fetches until the data source is healthy."
         if tickers:
             queued_message += f" Watchlist queued: {', '.join(tickers)}"
@@ -504,6 +505,12 @@ def main():
         else:
             st.info(queued_message)
             return
+
+    if not health_status.ok and has_rate_limit_signal and not bypass_health_gate:
+        st.info(
+            "Health probe reported throttling, but continuing with per-ticker fetches "
+            "in case data requests still succeed."
+        )
 
     batched_client = data_access.get_batched_ticker_client(tickers)
 


### PR DESCRIPTION
### Motivation
- The dashboard was aborting all ticker fetches whenever the Yahoo health probe reported an unhealthy status even for probe-only throttling (HTTP 429), which could permanently block live requests even when per-ticker requests might still succeed.

### Description
- Update `stock_dashboard/ui.py` to only hard-stop fetches when the health check is unhealthy for non-rate-limit reasons, and when the probe reports throttling (`rate_limit` present) the UI logs an informational message and continues with per-ticker fetch attempts (`has_rate_limit_signal` gating + message).

### Testing
- Ran `pytest -q` and all tests passed (`42 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd0f3a37488329bf8add0e983c76f8)